### PR TITLE
Add YouTube Video Screen

### DIFF
--- a/android/app/src/main/AndroidManifest.xml
+++ b/android/app/src/main/AndroidManifest.xml
@@ -1,4 +1,5 @@
 <manifest xmlns:android="http://schemas.android.com/apk/res/android">
+    <uses-permission android:name="android.permission.INTERNET"/>
     <application
         android:label="mastersMartialArts"
         android:name="${applicationName}"

--- a/ios/Runner/Info.plist
+++ b/ios/Runner/Info.plist
@@ -47,5 +47,10 @@
 	<true/>
 	<key>UIApplicationSupportsIndirectInputEvents</key>
 	<true/>
+	<key>NSAppTransportSecurity</key>
+	<dict>
+		<key>NSAllowsArbitraryLoads</key>
+		<true/>
+	</dict>
 </dict>
 </plist>

--- a/lib/components/menu_scaffold.dart
+++ b/lib/components/menu_scaffold.dart
@@ -17,7 +17,7 @@ class MenuScaffold extends StatelessWidget {
               title: const Text("Master's Martial Arts"),
               actions: routeNames
                   .map((route) => TextButton(
-                        onPressed: () => context.go('/$route'),
+                        onPressed: () => context.go('/${route.toLowerCase()}'),
                         child: Text(route),
                       ))
                   .toList(),
@@ -32,15 +32,23 @@ class MenuScaffold extends StatelessWidget {
             ),
             drawer: Drawer(
               child: ListView(
-                children: routeNames
-                    .map((route) => ListTile(
-                          title: Text(route),
-                          onTap: () {
-                            context.go('/$route');
-                            Navigator.of(context).pop();
-                          },
-                        ))
-                    .toList(),
+                children: [
+                  const DrawerHeader(
+                    decoration: BoxDecoration(
+                      color: Colors.blue,
+                    ),
+                    child: Text('Menu'),
+                  ),
+                  ...routeNames
+                      .map((route) => ListTile(
+                            title: Text(route),
+                            onTap: () {
+                              context.go('/${route.toLowerCase()}');
+                              Navigator.of(context).pop();
+                            },
+                          ))
+                      .toList(),
+                ],
               ),
             ),
             body: child,

--- a/lib/config/router.dart
+++ b/lib/config/router.dart
@@ -3,13 +3,15 @@ import 'package:flutter/material.dart';
 import 'package:go_router/go_router.dart';
 import 'package:mastersMartialArts/components/menu_scaffold.dart';
 import 'package:mastersMartialArts/screens/home/home_controller.dart';
-import 'package:mastersMartialArts/screens/splash_screen.dart'; // Import the splash screen
+import 'package:mastersMartialArts/screens/splash_screen.dart';
+import 'package:mastersMartialArts/screens/youtube_video_screen.dart';
 
 class AppRoutes {
   static const splash = 'splash';
   static const home = 'home';
+  static const youtubeVideo = 'youtube-video';
 
-  static const List<String> routes = [home];
+  static const List<String> routes = [home, youtubeVideo];
 }
 
 final router = GoRouter(
@@ -18,7 +20,7 @@ final router = GoRouter(
     GoRoute(
       path: '/',
       builder: (BuildContext context, GoRouterState state) {
-        return const SplashScreen(); // Splash screen as the initial route
+        return const SplashScreen();
       },
     ),
     GoRoute(
@@ -27,6 +29,15 @@ final router = GoRouter(
         return const MenuScaffold(
           routeNames: AppRoutes.routes,
           child: HomeController(),
+        );
+      },
+    ),
+    GoRoute(
+      path: '/youtube-video',
+      builder: (BuildContext context, GoRouterState state) {
+        return const MenuScaffold(
+          routeNames: AppRoutes.routes,
+          child: YouTubeVideoScreen(),
         );
       },
     ),

--- a/lib/screens/youtube_video_screen.dart
+++ b/lib/screens/youtube_video_screen.dart
@@ -15,7 +15,7 @@ class _YouTubeVideoScreenState extends State<YouTubeVideoScreen> {
   void initState() {
     super.initState();
     _controller = YoutubePlayerController(
-      initialVideoId: 'dQw4w9WgXcQ', // Replace with your video ID
+      initialVideoId: 'UR9-AP2yzY0', // Replace with your video ID
       flags: const YoutubePlayerFlags(
         autoPlay: true,
         mute: false,

--- a/lib/screens/youtube_video_screen.dart
+++ b/lib/screens/youtube_video_screen.dart
@@ -1,0 +1,44 @@
+import 'package:flutter/material.dart';
+import 'package:youtube_player_flutter/youtube_player_flutter.dart';
+
+class YouTubeVideoScreen extends StatefulWidget {
+  const YouTubeVideoScreen({Key? key}) : super(key: key);
+
+  @override
+  _YouTubeVideoScreenState createState() => _YouTubeVideoScreenState();
+}
+
+class _YouTubeVideoScreenState extends State<YouTubeVideoScreen> {
+  late YoutubePlayerController _controller;
+
+  @override
+  void initState() {
+    super.initState();
+    _controller = YoutubePlayerController(
+      initialVideoId: 'dQw4w9WgXcQ', // Replace with your video ID
+      flags: const YoutubePlayerFlags(
+        autoPlay: true,
+        mute: false,
+      ),
+    );
+  }
+
+  @override
+  Widget build(BuildContext context) {
+    return Scaffold(
+      appBar: AppBar(title: const Text('YouTube Video')),
+      body: Center(
+        child: YoutubePlayer(
+          controller: _controller,
+          showVideoProgressIndicator: true,
+        ),
+      ),
+    );
+  }
+
+  @override
+  void dispose() {
+    _controller.dispose();
+    super.dispose();
+  }
+}

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -17,6 +17,7 @@ dependencies:
   url_launcher: ^6.0.10
   cached_network_image: ^3.2.0
   responsive_framework: ^1.1.0
+  youtube_player_flutter: ^8.1.2
 
 dev_dependencies:
   flutter_test:


### PR DESCRIPTION
This PR adds a new screen that plays a specific YouTube video directly in the app. The changes include:

1. Added the YouTube player dependency (youtube_player_flutter) to pubspec.yaml.
2. Created a new YouTubeVideoScreen widget in lib/screens/youtube_video_screen.dart.
3. Updated the router configuration in lib/config/router.dart to include the new YouTube video screen.
4. Modified the MenuScaffold in lib/components/menu_scaffold.dart to include the new route in the navigation.
5. Added internet permission to the Android manifest file.
6. Updated the iOS Info.plist to allow non-HTTPS content for the YouTube player.

To test:
1. Run the app and navigate to the new YouTube video screen from the menu.
2. Verify that the YouTube video plays correctly within the app.
3. Test on both Android and iOS devices to ensure proper functionality.

Note: The current implementation uses a placeholder video ID. Replace 'dQw4w9WgXcQ' in the YouTubeVideoScreen with the desired video ID before merging.