### PR TITLE
Add Terms of Service Screen and Update Navigation

### DIFF
--- a/lib/components/menu_scaffold.dart
+++ b/lib/components/menu_scaffold.dart
@@ -18,7 +18,10 @@ class MenuScaffold extends StatelessWidget {
               actions: routeNames
                   .map((route) => TextButton(
                         onPressed: () => context.go('/${route.toLowerCase()}'),
-                        child: Text(route),
+                        child: Text(route.replaceAll('-', ' ')),
+                        style: TextButton.styleFrom(
+                          primary: Colors.white,
+                        ),
                       ))
                   .toList(),
             ),
@@ -41,7 +44,7 @@ class MenuScaffold extends StatelessWidget {
                   ),
                   ...routeNames
                       .map((route) => ListTile(
-                            title: Text(route),
+                            title: Text(route.replaceAll('-', ' ')),
                             onTap: () {
                               context.go('/${route.toLowerCase()}');
                               Navigator.of(context).pop();

--- a/lib/config/router.dart
+++ b/lib/config/router.dart
@@ -5,14 +5,16 @@ import 'package:mastersMartialArts/screens/home/home_controller.dart';
 import 'package:mastersMartialArts/screens/splash_screen.dart';
 import 'package:mastersMartialArts/screens/youtube_video_screen.dart';
 import 'package:mastersMartialArts/screens/techniques_catalog.dart';
+import 'package:mastersMartialArts/screens/terms_of_service_screen.dart';
 
 class AppRoutes {
   static const splash = 'splash';
   static const home = 'home';
   static const youtubeVideo = 'youtube-video';
   static const techniquesCatalog = 'techniques-catalog';
+  static const termsOfService = 'terms-of-service';
 
-  static const List<String> routes = [home, youtubeVideo, techniquesCatalog];
+  static const List<String> routes = [home, youtubeVideo, techniquesCatalog, termsOfService];
 }
 
 final router = GoRouter(
@@ -52,6 +54,15 @@ final router = GoRouter(
         return MenuScaffold(
           routeNames: AppRoutes.routes,
           child: TechniquesCatalog(),
+        );
+      },
+    ),
+    GoRoute(
+      path: '/terms-of-service',
+      builder: (BuildContext context, GoRouterState state) {
+        return const MenuScaffold(
+          routeNames: AppRoutes.routes,
+          child: TermsOfServiceScreen(),
         );
       },
     ),

--- a/lib/screens/home/home_controller.dart
+++ b/lib/screens/home/home_controller.dart
@@ -21,6 +21,11 @@ class HomeController extends StatelessWidget {
               child: const Text('Watch Sample Video'),
               onPressed: () => context.go('/youtube-video'),
             ),
+            SizedBox(height: 20),
+            ElevatedButton(
+              child: const Text('Terms of Service'),
+              onPressed: () => context.go('/terms-of-service'),
+            ),
           ],
         ),
       ),

--- a/lib/screens/terms_of_service_screen.dart
+++ b/lib/screens/terms_of_service_screen.dart
@@ -1,0 +1,47 @@
+import 'package:flutter/material.dart';
+
+class TermsOfServiceScreen extends StatelessWidget {
+  const TermsOfServiceScreen({Key? key}) : super(key: key);
+
+  @override
+  Widget build(BuildContext context) {
+    return Scaffold(
+      appBar: AppBar(
+        title: const Text('Terms of Service'),
+      ),
+      body: SingleChildScrollView(
+        padding: const EdgeInsets.all(16.0),
+        child: Column(
+          crossAxisAlignment: CrossAxisAlignment.start,
+          children: [
+            const Text(
+              'Terms of Service',
+              style: TextStyle(fontSize: 24, fontWeight: FontWeight.bold),
+            ),
+            const SizedBox(height: 16),
+            const Text(
+              'Please read these terms of service carefully before using our app.',
+              style: TextStyle(fontSize: 16),
+            ),
+            const SizedBox(height: 16),
+            const Text(
+              '1. Acceptance of Terms\n\n'
+              'By accessing or using our app, you agree to be bound by these Terms of Service. '
+              'If you do not agree to all the terms and conditions, then you may not access the app.\n\n'
+              '2. Use of the App\n\n'
+              'You agree to use the app only for lawful purposes and in a way that does not infringe '
+              'the rights of, restrict or inhibit anyone else\'s use and enjoyment of the app.\n\n'
+              '3. Intellectual Property\n\n'
+              'The content, organization, graphics, design, compilation, magnetic translation, digital '
+              'conversion and other matters related to the app are protected under applicable copyrights, '
+              'trademarks and other proprietary rights.\n\n'
+              '4. Disclaimer of Warranties\n\n'
+              'The app is provided "as is" without any representations or warranties, express or implied.',
+              style: TextStyle(fontSize: 16),
+            ),
+          ],
+        ),
+      ),
+    );
+  }
+}


### PR DESCRIPTION
This PR adds a new Terms of Service screen to the application and updates the navigation to include access to this new screen. The changes include:

1. Created a new `TermsOfServiceScreen` widget with placeholder content.
2. Updated the router configuration to include the new Terms of Service route.
3. Added a new button on the home screen to navigate to the Terms of Service screen.
4. Updated the `MenuScaffold` to include the Terms of Service option in both the AppBar (for wide screens) and the Drawer (for narrow screens).

These changes improve the app's functionality by providing users with easy access to the Terms of Service, which is an important legal document for any application.

To test:
1. Run the app and verify that the Terms of Service button appears on the home screen.
2. Click the Terms of Service button and ensure it navigates to the new screen.
3. Check that the Terms of Service screen displays the content correctly.
4. Verify that the menu (both in the AppBar for wide screens and in the Drawer for narrow screens) includes the Terms of Service option.
5. Test navigation between all screens to ensure it works as expected.

Note: The current Terms of Service content is a placeholder and should be replaced with the actual terms of service for the app before release.